### PR TITLE
Move result object to function

### DIFF
--- a/lib/services/facebook.service.js
+++ b/lib/services/facebook.service.js
@@ -3,12 +3,11 @@ var serviceName         = "facebook";
 var request             = require("request");
 var serviceConfig       = require("./../config/services.config.json");
 
-var result = {
-    service: serviceName,
-    status: false
-}
-
 function facebook (cb) {
+    var result = {
+        service: serviceName,
+        status: false
+    };
 
     request({
         url: serviceConfig[serviceName],

--- a/lib/services/github.service.js
+++ b/lib/services/github.service.js
@@ -3,17 +3,18 @@ var serviceName         = "github";
 var request             = require("request");
 var serviceConfig       = require("./../config/services.config.json");
 
-var statusMessage       = {
+var statusMessage = {
     good: "Everything operating normally.",
     minor: "Minor Problems",
     major: "Red Alert - Github may be down."
 };
-var result              = {
-    service: serviceName,
-    status: false
-}
 
 function github (cb) {
+    var result = {
+        service: serviceName,
+        status: false
+    };
+
     request({
         url: serviceConfig[serviceName],
         method: "GET",

--- a/lib/services/heroku.service.js
+++ b/lib/services/heroku.service.js
@@ -3,59 +3,59 @@ var serviceName         = "heroku";
 var request             = require("request");
 var serviceConfig       = require("./../config/services.config.json");
 
-var result = {
-    service: serviceName,
-    status: false
-}
-
 function heroku (cb) {
-  request({
-      url: serviceConfig[serviceName],
-      method: "GET",
-      headers: {
-          "User-Agent": 'request'
-      }
-  }, function (error, response, body) {
-      if(error) {
-          result["message"]       = "Problem with the connection.";
-          result["data"]          = error;
-          return cb(result);
-      }
+    var result = {
+        service: serviceName,
+        status: false
+    }
 
-      if(body) {
-          try {
-              body = JSON.parse(body);
-          } catch (e) {
-              result["message"]    = "Could not parse the response.";
-              return cb(result);
-          }
+    request({
+        url: serviceConfig[serviceName],
+        method: "GET",
+        headers: {
+            "User-Agent": 'request'
+        }
+    }, function (error, response, body) {
+        if(error) {
+            result["message"]       = "Problem with the connection.";
+            result["data"]          = error;
+            return cb(result);
+        }
 
-          if(body.status.Production != "green" && body.status.Development != "green") {
-              result['message']     = "Production and Development unhealthy.";
-              result['data']        = body.issues;
-              return cb(result);
-          }
+        if(body) {
+            try {
+                body = JSON.parse(body);
+            } catch (e) {
+                result["message"]    = "Could not parse the response.";
+                return cb(result);
+            }
 
-          if(body.status.Production != "green") {
-              result['message']     = "Production unhealthy.";
-              result['data']        = body.issues;
-              return cb(result);
-          }
+            if(body.status.Production != "green" && body.status.Development != "green") {
+                result['message']     = "Production and Development unhealthy.";
+                result['data']        = body.issues;
+                return cb(result);
+            }
 
-          if(body.status.Development != "green") {
-              result['message']     = "Development unhealthy";
-              result['data']        = body.issues;
-              return cb(result);
-          }
+            if(body.status.Production != "green") {
+                result['message']     = "Production unhealthy.";
+                result['data']        = body.issues;
+                return cb(result);
+            }
 
-          result["status"]          = true;
-          result["message"]         = "Service healthy.";
-          return cb(result);
-      }
+            if(body.status.Development != "green") {
+                result['message']     = "Development unhealthy";
+                result['data']        = body.issues;
+                return cb(result);
+            }
 
-      result["message"]   = "Empty response. Try Again.";
-      return cb(result);
-  });
+            result["status"]          = true;
+            result["message"]         = "Service healthy.";
+            return cb(result);
+        }
+
+        result["message"]   = "Empty response. Try Again.";
+        return cb(result);
+    });
 }
 
 module.exports = heroku;


### PR DESCRIPTION
Explained in the comments of #10 

Consider the following (with the old code):
1. upstate.facebook() is called when the Facebook service is healthy. result.status would be set to true.
2. upstate.facebook() is called a few minutes later, and suddenly Facebook's API indicates status problems. This is where the bug appears: the callback will be called and status will be true, instead of the false it should return since Facebook has problems. This problem occurs since the result object isn't bound to a specific function call, but rather to all calls to upstate.facebook().

The Heroku diff is a bit bigger because part of the file was indented with 2 spaces, while other parts were indented with 4. For consistency reasons with the rest, I added spaces where necessary to make it completely 4-space-indented.